### PR TITLE
W-21553100: Update MuleSoft Help Center links to Salesforce Help

### DIFF
--- a/modules/ROOT/pages/gov-cloud-account-setup.adoc
+++ b/modules/ROOT/pages/gov-cloud-account-setup.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 After you set up your account, Government Cloud works with your identity provider (IdP) to enable single sign-on (SSO) for users in your agency. Instead of using the Anypoint Platform sign-in page, your users sign in to the SSO system to access Anypoint Platform.
 
-When you purchase Government Cloud, your Customer Success Manager sends you onboarding instructions and access to the https://help.mulesoft.com[MuleSoft Help Center].
+When you purchase Government Cloud, your Customer Success Manager sends you onboarding instructions and access to the https://help.salesforce.com[Salesforce Help].
 
 To configure your IdP to work with Government Cloud:
 


### PR DESCRIPTION
Updates all "https://help.mulesoft.com[MuleSoft Help Center]" references to "https://help.salesforce.com[Salesforce Help]" and removes the ^ from link text.