### PR TITLE
@W-22920776 Correct API proxy hybrid target support status for GovCloud

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -122,7 +122,7 @@ The Salesforce menu option in Access Management is not available in Government C
 
 |xref:api-manager::latest-overview-concept.adoc[API Manager]
 |Manage, govern, and secure the APIs you deploy to Anypoint Platform.
-|The feature to xref:api-manager::proxy-latest-concept.adoc[deploy an API proxy] to hybrid targets is not available in Government Cloud.
+|N/A
 
 |xref:runtime-manager::index.adoc[Runtime Manager]
 |Deploy, manage, and monitor your Mule applications in a sandbox, staging, or production environment from one central location, whether your apps are deployed in the cloud or on-premises.


### PR DESCRIPTION
## Summary

- Removes the incorrect limitation note stating that deploying an API proxy to hybrid targets is not available in Government Cloud
- Feature has been validated end-to-end on GovCloud (gstg): API proxy created, deployed to Hybrid server, traffic proxied successfully
- Updates the API Manager row in the features table to `N/A` (no limitations), consistent with other supported features

## Test plan

- [ ] Verify the API Manager row in the features table on the Gov Cloud overview page no longer shows a hybrid proxy limitation
- [ ] Confirm `N/A` renders correctly in the table

Fixes: W-22920776